### PR TITLE
fix: run setup job with correct command

### DIFF
--- a/internal/job/setup.go
+++ b/internal/job/setup.go
@@ -39,13 +39,13 @@ func SetupJob(store *v1.Store) *batchv1.Job {
 	}
 	maps.Copy(labels, util.GetDefaultLabels(store))
 
-	var stringCommand string
+	var command []string
 	if store.Spec.SetupHook.Before != "" {
-		stringCommand = fmt.Sprintf("%s %s", stringCommand, store.Spec.SetupHook.Before)
+		command = append(command, store.Spec.SetupHook.Before)
 	}
-	stringCommand = fmt.Sprintf("%s sleep 5", stringCommand)
+	command = append(command, "/setup")
 	if store.Spec.SetupHook.After != "" {
-		stringCommand = fmt.Sprintf("%s %s", stringCommand, store.Spec.SetupHook.After)
+		command = append(command, store.Spec.SetupHook.After)
 	}
 
 	envs := append(store.GetEnv(),
@@ -71,8 +71,8 @@ func SetupJob(store *v1.Store) *batchv1.Job {
 		VolumeMounts:    store.Spec.Container.VolumeMounts,
 		ImagePullPolicy: store.Spec.Container.ImagePullPolicy,
 		Image:           store.Spec.Container.Image,
-		Command:         []string{"sh"},
-		Args:            []string{"-c", stringCommand},
+		Command:         []string{"sh", "-c"},
+		Args:            command,
 		Env:             envs,
 	})
 


### PR DESCRIPTION
The setup job had the wrong command and therefore was not able to setup the shop correctly.