### PR TITLE
chore: upgrade golangci-lint to v2

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,9 +21,9 @@ jobs:
           go-version-file: go.mod
 
       - name: Run linter
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.63.4
+          version: v2.0
           args: --timeout=8m --verbose
 
   go-test:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,40 +1,40 @@
+version: "2"
 run:
   allow-parallel-runners: true
-
-issues:
-  # don't skip warning about doc comments
-  # don't exclude the default set of lint
-  exclude-use-default: false
-  # restore some of the defaults
-  # (fill in the rest as needed)
-  exclude-rules:
-    - path: "api/*"
-      linters:
-        - lll
-    - path: "api/v1/store_test.go"
-      linters:
-        - dupl
-    - path: "internal/*"
-      linters:
-        - dupl
-        - lll
 linters:
-  disable-all: false
   enable:
     - dupl
-    - errcheck
     - gocyclo
-    - gofmt
-    - goimports
-    - gosimple
-    - govet
-    - ineffassign
     - lll
     - misspell
     - nakedret
     - prealloc
-    - staticcheck
-    - typecheck
     - unconvert
     - unparam
-    - unused
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - lll
+        path: api/*
+      - linters:
+          - dupl
+        path: api/v1/store_test.go
+      - linters:
+          - dupl
+          - lll
+        path: internal/*
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/internal/controller/store_controller.go
+++ b/internal/controller/store_controller.go
@@ -283,7 +283,7 @@ func (r *StoreReconciler) ensureAppSecrets(ctx context.Context, store *v1.Store)
 	}
 
 	if store.Spec.OpensearchSpec.Enabled && (store.Spec.OpensearchSpec.PasswordSecretRef.Name == "" || store.Spec.OpensearchSpec.PasswordSecretRef.Key == "") {
-		return fmt.Errorf("opensearch passwordSecretRef key or name is empty for store %s.", store.Name)
+		return fmt.Errorf("opensearch passwordSecretRef key or name is empty for store %s", store.Name)
 	}
 
 	var esp []byte

--- a/internal/deployment/util.go
+++ b/internal/deployment/util.go
@@ -32,5 +32,5 @@ func GetStoreDeploymentImage(
 			return container.Image, nil
 		}
 	}
-	return "", fmt.Errorf("Could'n find storefront deployment container")
+	return "", fmt.Errorf("could not find storefront deployment container")
 }

--- a/internal/k8s/utils.go
+++ b/internal/k8s/utils.go
@@ -70,7 +70,7 @@ func GetOperatorNamespace() (string, error) {
 	}
 
 	return "", fmt.Errorf(
-		"Eigther set the namespace via env `%s` or run the operator as a pod",
+		"either set the namespace via env `%s` or run the operator as a pod",
 		"OPERATOR_NAMESPACE",
 	)
 }


### PR DESCRIPTION
This pull request includes updates to the linting configuration and workflow for the project. The changes primarily focus on updating the linter action version and refining the linting rules and exclusions.

Updates to linting configuration and workflow:

* [`.github/workflows/lint.yaml`](diffhunk://#diff-4b122024a3a28ded65da76a2f1bface1f3a27328374438d1298d25585fe0603bL24-R26): Updated the `golangci-lint-action` to version 7 and the linter version to v2 for improved linting capabilities.
* [`.golangci.yml`](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9R1-R40): Revised the configuration to version 2, removed outdated issue rules, and restructured the linters and exclusions for better maintainability and clarity.