### PR TITLE
fix: use util function in service selector

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,7 +9,6 @@ rules:
   - ""
   resources:
   - pods
-  - service
   verbs:
   - create
   - delete
@@ -20,9 +19,19 @@ rules:
   - ""
   resources:
   - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/internal/controller/storedebuginstance_controller.go
+++ b/internal/controller/storedebuginstance_controller.go
@@ -48,7 +48,7 @@ type StoreDebugInstanceReconciler struct {
 // +kubebuilder:rbac:groups=shop.shopware.com,namespace=default,resources=storedebuginstances/finalizers,verbs=update
 // +kubebuilder:rbac:groups=shop.shopware.com,namespace=default,resources=stores,verbs=get
 // +kubebuilder:rbac:groups="",namespace=default,resources=pods,verbs=get;list;watch;create;delete;
-// +kubebuilder:rbac:groups="",namespace=default,resources=service,verbs=get;list;watch;create;delete;
+// +kubebuilder:rbac:groups="",namespace=default,resources=services,verbs=get;list;watch;create;delete;
 
 func (r *StoreDebugInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (rr ctrl.Result, err error) {
 	log := logging.FromContext(ctx).

--- a/internal/service/debug.go
+++ b/internal/service/debug.go
@@ -28,6 +28,8 @@ func DebugService(store v1.Store, debugInstance v1.StoreDebugInstance) *corev1.S
 		})
 	}
 
+	selector := util.GetDefaultStoreInstanceDebugLabels(store, debugInstance)
+
 	return &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -39,13 +41,9 @@ func DebugService(store v1.Store, debugInstance v1.StoreDebugInstance) *corev1.S
 			Labels:    util.GetDefaultStoreLabels(store),
 		},
 		Spec: corev1.ServiceSpec{
-			Selector: map[string]string{
-				"shop.shopware.com/store.debug":          "true",
-				"shop.shopware.com/store.debug.instance": debugInstance.Name,
-				"shop.shopware.com/store.app":            "shopware-storefront",
-			},
-			Type:  corev1.ServiceTypeClusterIP,
-			Ports: ports,
+			Selector: selector,
+			Type:     corev1.ServiceTypeClusterIP,
+			Ports:    ports,
 		},
 	}
 }


### PR DESCRIPTION
This pull request includes several changes to the RBAC configuration, controller, and service files. The changes primarily focus on updating resource names and improving the service selector logic.

RBAC configuration updates:

* [`config/rbac/role.yaml`](diffhunk://#diff-6d4c4e29ec096149781536bb9118fde8242c1901df764e3eda3019ac8503d6c7L12): Removed `service` from the resources list and added `services` with appropriate verbs under `rules:`. [[1]](diffhunk://#diff-6d4c4e29ec096149781536bb9118fde8242c1901df764e3eda3019ac8503d6c7L12) [[2]](diffhunk://#diff-6d4c4e29ec096149781536bb9118fde8242c1901df764e3eda3019ac8503d6c7R22-R34)

Controller updates:

* [`internal/controller/storedebuginstance_controller.go`](diffhunk://#diff-967484c763b28f00ec6c6f8c418658b3dce1a523fa6e911ef8b56fcd9a574688L51-R51): Corrected the resource name from `service` to `services` in the RBAC annotations.

Service updates:

* [`internal/service/debug.go`](diffhunk://#diff-7b0425cf0799e1e6e719f51696e24a92706204608a3819979b4d7f4d711deef7R31-R32): Added a new `selector` variable using `util.GetDefaultStoreInstanceDebugLabels` and updated the `ServiceSpec` to use this selector. [[1]](diffhunk://#diff-7b0425cf0799e1e6e719f51696e24a92706204608a3819979b4d7f4d711deef7R31-R32) [[2]](diffhunk://#diff-7b0425cf0799e1e6e719f51696e24a92706204608a3819979b4d7f4d711deef7L42-R44)