### PR TITLE
feat: Added pod labels configuration

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
         {{- end }}
       labels:
         control-plane: shopware-operator
+        {{- with .Values.podLabels }}
+            {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- if hasKey .Values "affinity" }}
       affinity:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -84,6 +84,7 @@ tolerations: []
 
 labels: {}
 podAnnotations: {}
+podLabels: {}
 
 # Supported levels: debug, info, warn, error, dpanic, panic, fatal
 logLevel: info


### PR DESCRIPTION
This pull request introduces enhancements to the Helm chart configuration, focusing on enabling custom pod labels for deployments. The changes improve flexibility by allowing users to specify additional labels for pods via the Helm values file.

### Helm chart configuration updates:

* [`helm/templates/deployment.yaml`](diffhunk://#diff-a63ea33c81187c63a5163e4042419e5cce470581f485a1c99914c655f5570435R36-R38): Added support for custom pod labels by introducing a block that processes `.Values.podLabels` and applies them to the pod's metadata using `toYaml` and `nindent`.
* [`helm/values.yaml`](diffhunk://#diff-81801117ec01136c8a49bfcd42af8e104f4efad1f2daccda9da9d960eaad5279R87): Added a new `podLabels` field in the values file to allow users to define custom labels for pods.