### PR TITLE
Added ttlSecondsAfterFinished for migration job

### DIFF
--- a/internal/job/command.go
+++ b/internal/job/command.go
@@ -120,8 +120,6 @@ func getJobSpec(store v1.Store, ex v1.StoreExec, labels map[string]string) batch
 
 	envs := util.MergeEnv(store.GetEnv(), ex.Spec.ExtraEnvs)
 
-	ttlSecondsAfterFinished := int32(86400) // Hardcoded to 1 day for now
-
 	containers := append(store.Spec.Container.ExtraContainers, corev1.Container{
 		Name:            CONTAINER_NAME_COMMAND,
 		VolumeMounts:    store.Spec.Container.VolumeMounts,

--- a/internal/job/command.go
+++ b/internal/job/command.go
@@ -120,6 +120,8 @@ func getJobSpec(store v1.Store, ex v1.StoreExec, labels map[string]string) batch
 
 	envs := util.MergeEnv(store.GetEnv(), ex.Spec.ExtraEnvs)
 
+	ttlSecondsAfterFinished := int32(86400) // Hardcoded to 1 day for now
+
 	containers := append(store.Spec.Container.ExtraContainers, corev1.Container{
 		Name:            CONTAINER_NAME_COMMAND,
 		VolumeMounts:    store.Spec.Container.VolumeMounts,
@@ -141,7 +143,8 @@ func getJobSpec(store v1.Store, ex v1.StoreExec, labels map[string]string) batch
 	}
 
 	return batchv1.JobSpec{
-		BackoffLimit: &ex.Spec.MaxRetries,
+		BackoffLimit:            &ex.Spec.MaxRetries,
+		TTLSecondsAfterFinished: &ttlSecondsAfterFinished,
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: labels,

--- a/internal/job/migration.go
+++ b/internal/job/migration.go
@@ -41,7 +41,7 @@ func MigrationJob(store v1.Store) *batchv1.Job {
 
 	backoffLimit := int32(3)
 	sharedProcessNamespace := true
-	ttlSecondsAfterFinished := int32(86400) // Hardedcoded to 1 day for now
+	ttlSecondsAfterFinished := int32(86400) // Hardcoded to 1 day for now
 
 	labels := util.GetDefaultContainerStoreLabels(store, store.Spec.MigrationJobContainer.Labels)
 	labels["shop.shopware.com/store.hash"] = GetMigrateHash(store)

--- a/internal/job/migration.go
+++ b/internal/job/migration.go
@@ -41,6 +41,7 @@ func MigrationJob(store v1.Store) *batchv1.Job {
 
 	backoffLimit := int32(3)
 	sharedProcessNamespace := true
+	ttlSecondsAfterFinished := int32(86400) // Hardedcoded to 1 day for now
 
 	labels := util.GetDefaultContainerStoreLabels(store, store.Spec.MigrationJobContainer.Labels)
 	labels["shop.shopware.com/store.hash"] = GetMigrateHash(store)
@@ -72,7 +73,8 @@ func MigrationJob(store v1.Store) *batchv1.Job {
 			Annotations: annotations,
 		},
 		Spec: batchv1.JobSpec{
-			BackoffLimit: &backoffLimit,
+			BackoffLimit:            &backoffLimit,
+			TTLSecondsAfterFinished: &ttlSecondsAfterFinished,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      labels,

--- a/internal/job/migration.go
+++ b/internal/job/migration.go
@@ -41,7 +41,6 @@ func MigrationJob(store v1.Store) *batchv1.Job {
 
 	backoffLimit := int32(3)
 	sharedProcessNamespace := true
-	ttlSecondsAfterFinished := int32(86400) // Hardcoded to 1 day for now
 
 	labels := util.GetDefaultContainerStoreLabels(store, store.Spec.MigrationJobContainer.Labels)
 	labels["shop.shopware.com/store.hash"] = GetMigrateHash(store)

--- a/internal/job/setup.go
+++ b/internal/job/setup.go
@@ -34,6 +34,7 @@ func SetupJob(store v1.Store) *batchv1.Job {
 
 	sharedProcessNamespace := true
 	backoffLimit := int32(3)
+	ttlSecondsAfterFinished := int32(86400) // Hardcoded to 1 day for now
 
 	labels := util.GetDefaultContainerStoreLabels(store, store.Spec.MigrationJobContainer.Labels)
 	labels["shop.shopware.com/store.type"] = "setup"
@@ -82,7 +83,8 @@ func SetupJob(store v1.Store) *batchv1.Job {
 			Annotations: annotations,
 		},
 		Spec: batchv1.JobSpec{
-			BackoffLimit: &backoffLimit,
+			BackoffLimit:            &backoffLimit,
+			TTLSecondsAfterFinished: &ttlSecondsAfterFinished,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      labels,

--- a/internal/job/setup.go
+++ b/internal/job/setup.go
@@ -34,7 +34,6 @@ func SetupJob(store v1.Store) *batchv1.Job {
 
 	sharedProcessNamespace := true
 	backoffLimit := int32(3)
-	ttlSecondsAfterFinished := int32(86400) // Hardcoded to 1 day for now
 
 	labels := util.GetDefaultContainerStoreLabels(store, store.Spec.MigrationJobContainer.Labels)
 	labels["shop.shopware.com/store.type"] = "setup"

--- a/internal/job/util.go
+++ b/internal/job/util.go
@@ -12,6 +12,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+var ttlSecondsAfterFinished int32 = 86400 // Hardcoded to 1 day for now
+
 type JobState struct {
 	ExitCode int
 	Running  bool


### PR DESCRIPTION
This pull request makes a small change to the migration job configuration by setting a time-to-live (TTL) for completed jobs. This helps ensure that finished migration jobs are cleaned up automatically after a set period.

* Added `ttlSecondsAfterFinished` to the `MigrationJob` in `internal/job/migration.go`, hardcoded to 1 day (86400 seconds), so finished jobs will be deleted after this period. [[1]](diffhunk://#diff-e438da5d1087f581637403c4778b568b04237187ba8584087b1f5f1fb5f91cadR44) [[2]](diffhunk://#diff-e438da5d1087f581637403c4778b568b04237187ba8584087b1f5f1fb5f91cadR77)