### PR TITLE
feat: add admin opensearch-admin-url

### DIFF
--- a/api/v1/store_env.go
+++ b/api/v1/store_env.go
@@ -151,6 +151,17 @@ func (s *Store) getOpensearch() []corev1.EnvVar {
 				},
 			},
 			{
+				Name: "ADMIN_OPENSEARCH_URL",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: s.Spec.SecretName,
+						},
+						Key: "opensearch-url",
+					},
+				},
+			},
+			{
 				Name:  "SHOPWARE_ES_ENABLED",
 				Value: "1",
 			},


### PR DESCRIPTION
To also be able to use opensearch for the shopware admin the environment variable `ADMIN_OPENSEARCH_URL` needs to be set.

https://developer.shopware.com/docs/guides/hosting/infrastructure/elasticsearch/elasticsearch-setup.html