### PR TITLE
fix: creating snapshots of S3 objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /config/crd/bases/*
 
 # Binaries for programs and plugins
+.DS_Store
 *.exe
 *.exe~
 *.dll

--- a/internal/snapshot/s3.go
+++ b/internal/snapshot/s3.go
@@ -170,7 +170,7 @@ func (s *SnapshotService) createAssetBackup(
 			))
 		if err != nil {
 			logger.Errorw("bucket backup failed", zap.Error(err))
-			errChan <- fmt.Errorf("bucket backup: %w", err)
+			errChan <- fmt.Errorf("private bucket backup: %w", err)
 		}
 
 		logger.Info("Done S3 bucket read")
@@ -191,7 +191,7 @@ func (s *SnapshotService) createAssetBackup(
 			))
 		if err != nil {
 			logger.Errorw("bucket backup failed", zap.Error(err))
-			errChan <- fmt.Errorf("bucket backup: %w", err)
+			errChan <- fmt.Errorf("public bucket backup: %w", err)
 		}
 
 		logger.Info("Done S3 bucket read")
@@ -213,9 +213,12 @@ func (s *SnapshotService) createAssetBackup(
 	return nil
 }
 
-func processDownloadObject(acrhiveDirPath string, logger *zap.SugaredLogger) func(i minio.ObjectInfo, o *minio.Object) error {
+func processDownloadObject(archiveDirPath string, logger *zap.SugaredLogger) func(i minio.ObjectInfo, o *minio.Object) error {
 	return func(i minio.ObjectInfo, o *minio.Object) error {
-		file := filepath.Join(acrhiveDirPath, i.Key)
+		//nolint: errcheck
+		defer o.Close()
+
+		file := filepath.Join(archiveDirPath, i.Key)
 		if err := os.MkdirAll(filepath.Dir(file), 0755); err != nil {
 			return fmt.Errorf("failed to create directory: %w", err)
 		}
@@ -239,7 +242,7 @@ func processDownloadObject(acrhiveDirPath string, logger *zap.SugaredLogger) fun
 			return fmt.Errorf("failed to copy object to file: %w", err)
 		}
 
-		return o.Close()
+		return nil
 	}
 }
 

--- a/internal/util/s3.go
+++ b/internal/util/s3.go
@@ -355,10 +355,6 @@ func NewS3Downloader(client *minio.Client, bucket string) *S3Downloader {
 }
 
 func (s *S3Downloader) DownloadBucket(ctx context.Context, batchCount int, f func(minio.ObjectInfo, *minio.Object) error) error {
-	objects := s.client.ListObjects(ctx, s.bucket, minio.ListObjectsOptions{
-		Recursive: true,
-	})
-
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -366,11 +362,15 @@ func (s *S3Downloader) DownloadBucket(ctx context.Context, batchCount int, f fun
 	errCh := make(chan error, 1)
 	sem := make(chan struct{}, batchCount)
 
+	objects := s.client.ListObjects(ctx, s.bucket, minio.ListObjectsOptions{
+		Recursive: true,
+	})
 	for object := range objects {
 		if object.Err != nil {
 			return fmt.Errorf("error listing objects: %w", object.Err)
 		}
 
+		// Check if we've already failed
 		select {
 		case <-ctx.Done():
 			return ctx.Err()


### PR DESCRIPTION
This pull request refactors and improves the S3 backup logic for asset snapshots, focusing on code reuse, error handling, and concurrency management. The main change is the extraction of the S3 object download logic into a reusable function, which simplifies the backup process for both private and public buckets. Additionally, the S3 downloader's concurrency and error propagation mechanisms are improved for reliability.

**Refactoring and code reuse:**
- Extracted the S3 object download logic into a new helper function, `processDownloadObject`, which is now used for both private and public bucket backups. This reduces code duplication and centralizes file handling and error reporting. [[1]](diffhunk://#diff-caa16d04031a0463aadd36fc03a6662d8119406f2a66496ead9e530f4b4cdf2cL162-R197) [[2]](diffhunk://#diff-caa16d04031a0463aadd36fc03a6662d8119406f2a66496ead9e530f4b4cdf2cR216-R248)

**Error handling and logging improvements:**
- Improved error reporting and logging in the backup process, ensuring that errors are logged with consistent messages and that context (such as the bucket name) is included in log entries.

**S3 downloader concurrency and error propagation:**
- Enhanced the `DownloadBucket` method in `S3Downloader` to ensure that the error channel is properly closed after all goroutines complete, and that the first encountered error is returned immediately to halt further processing. Also added explicit comments and improved semaphore handling for clarity. [[1]](diffhunk://#diff-cb89a2bcc2a1c0fd26abcef899159c407deec09838c7dddbc109eb5ac17c577aL358-R373) [[2]](diffhunk://#diff-cb89a2bcc2a1c0fd26abcef899159c407deec09838c7dddbc109eb5ac17c577aR384) [[3]](diffhunk://#diff-cb89a2bcc2a1c0fd26abcef899159c407deec09838c7dddbc109eb5ac17c577aL395-R396) [[4]](diffhunk://#diff-cb89a2bcc2a1c0fd26abcef899159c407deec09838c7dddbc109eb5ac17c577aL405-L426)

**Minor improvements:**
- Added the `strings` package import to support directory/file checks in the new download logic.