### PR TITLE
fix: remove gatewayapi need

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -190,6 +190,11 @@ jobs:
             exit 1
           fi
 
+          if grep -i "error" operator-logs.txt; then
+            echo "ERROR: Found error in operator logs"
+            exit 1
+          fi
+
           echo "No permission or unhandled errors found in operator logs"
 
           # Cleanup test resources

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -56,8 +56,11 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
 	utilruntime.Must(shopv1.AddToScheme(scheme))
-	utilruntime.Must(gatewayv1.Install(scheme))
 	//+kubebuilder:scaffold:scheme
+	//
+	// Ignore errors because gateway-api is not per default installed
+	// nolint:errcheck
+	gatewayv1.Install(scheme)
 }
 
 func main() {


### PR DESCRIPTION
This makes sure the operator is still starting when the gateway api is
not needed. In the init function is already httpRoute and Gateway
registered
