### PR TITLE
fix: endless loop with foreground finalizer

### DIFF
--- a/internal/controller/store_controller.go
+++ b/internal/controller/store_controller.go
@@ -159,6 +159,10 @@ func (r *StoreReconciler) Reconcile(
 	// 	return rr, r.applyFinalizers(ctx, store)
 	// }
 
+	if !store.DeletionTimestamp.IsZero() {
+		return shortRequeue, nil
+	}
+
 	if err := r.doReconcile(ctx, store); err != nil {
 		log.Errorw("reconcile", zap.Error(err))
 		return rr, nil


### PR DESCRIPTION
We are not checking if the store is deleted, we now jump out directly if
the store is deleted
