### PR TITLE
feat: add MESSENGER_CONSUMER_NAME env var

### DIFF
--- a/api/v1/store_env.go
+++ b/api/v1/store_env.go
@@ -211,11 +211,20 @@ func (s *Store) getWorker() []corev1.EnvVar {
 			{
 				Name: "MESSENGER_TRANSPORT_DSN",
 				Value: fmt.Sprintf(
-					"redis://%s:%d/messages/symfony/consumer?auto_setup=true&serializer=1&stream_max_entries=0&dbindex=%d",
+					"redis://%s:%d/messages/symfony?auto_setup=true&serializer=1&stream_max_entries=0&dbindex=%d",
 					s.Spec.Worker.RedisHost,
 					s.Spec.Worker.RedisPort,
 					s.Spec.Worker.RedisIndex,
 				),
+			},
+			{
+				Name: "MESSENGER_CONSUMER_NAME",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						APIVersion: "v1",
+						FieldPath:  "metadata.name",
+					},
+				},
 			},
 		}
 	}

--- a/api/v1/store_test.go
+++ b/api/v1/store_test.go
@@ -573,7 +573,7 @@ func TestWorkerRedisDsnOverwrite(t *testing.T) {
 		for _, envVar := range env {
 			if envVar.Name == "MESSENGER_TRANSPORT_DSN" {
 				foundDSN = true
-				assert.Equal(t, "redis://worker-host:6379/messages/symfony/consumer?auto_setup=true&serializer=1&stream_max_entries=0&dbindex=3", envVar.Value)
+				assert.Equal(t, "redis://worker-host:6379/messages/symfony?auto_setup=true&serializer=1&stream_max_entries=0&dbindex=3", envVar.Value)
 			}
 			if envVar.Name == "MESSENGER_CONSUMER_NAME" {
 				foundConsumerName = true


### PR DESCRIPTION
This pull request updates the environment variables for worker containers and improves the related test coverage. The main changes involve adding a new environment variable to expose the consumer name and modifying the Redis DSN format for workers.

**Environment variable improvements:**

* Added a new environment variable `MESSENGER_CONSUMER_NAME` for worker containers, which is dynamically set to the Pod's metadata name using a field reference. [[1]](diffhunk://#diff-4f99a8460f781f6a9948924b626f2c0ec87a282f6060e1d40df291dc6c103effR197-R205) [[2]](diffhunk://#diff-4f99a8460f781f6a9948924b626f2c0ec87a282f6060e1d40df291dc6c103effL205-R228)

**Redis DSN updates:**

* Updated the `MESSENGER_TRANSPORT_DSN` value for workers to remove the `/consumer` segment from the Redis DSN path, aligning it with the expected format. [[1]](diffhunk://#diff-4f99a8460f781f6a9948924b626f2c0ec87a282f6060e1d40df291dc6c103effL205-R228) [[2]](diffhunk://#diff-04642290a2306491c631302dbf7b745fdf5c70c163b6e58cfe3851a73fcc3e3fL568-R583)

**Test enhancements:**

* Updated tests in `store_test.go` to check for the presence of the new `MESSENGER_CONSUMER_NAME` environment variable and to verify the modified Redis DSN format. [[1]](diffhunk://#diff-04642290a2306491c631302dbf7b745fdf5c70c163b6e58cfe3851a73fcc3e3fL543-R554) [[2]](diffhunk://#diff-04642290a2306491c631302dbf7b745fdf5c70c163b6e58cfe3851a73fcc3e3fL568-R583)