### PR TITLE
fix: Use worker deployment when checking store state

### DIFF
--- a/internal/controller/store_status.go
+++ b/internal/controller/store_status.go
@@ -523,7 +523,7 @@ func (r *StoreReconciler) stateInitializing(
 		return v1.StateInitializing
 	}
 
-	worker, err := deployment.GetAdminDeployment(ctx, *store, r.Client)
+	worker, err := deployment.GetWorkerDeployment(ctx, *store, r.Client)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return v1.StateInitializing


### PR DESCRIPTION
This pull request updates the logic for determining the initialization state of a store in the `StoreReconciler`. The main change is that it now uses the worker deployment instead of the admin deployment to check the store's worker status.