### PR TITLE
feat: add validating webhook

### DIFF
--- a/.github/testdata/invalid_store_override.yaml
+++ b/.github/testdata/invalid_store_override.yaml
@@ -1,0 +1,26 @@
+apiVersion: shop.shopware.com/v1
+kind: Store
+metadata:
+  name: invalid-container-override
+spec:
+  adminCredentials:
+    username: admin
+  appCache:
+    adapter: builtin
+  cdnURL: ""
+  container:
+    image: example.com/shopware:test
+  database:
+    host: mysql
+    passwordSecretRef:
+      key: password
+      name: database
+    user: shopware
+    version: "8.0"
+  secretName: store-secret
+  sessionCache:
+    adapter: builtin
+  worker:
+    adapter: builtin
+  workerDeploymentContainer:
+    unexpectedField: true

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -38,7 +38,9 @@ jobs:
           go-version-file: go.mod
           cache: true
       - name: Run go tests
-        run: go test ./...
+        run: |
+          make manifests
+          go test ./...
 
   helm-lint:
     name: helm lint
@@ -60,6 +62,12 @@ jobs:
           make helm path=test version=99.99.98
           cd test
           helm lint .
+          helm template no-webhook . --set crds.install=false --set webhook.enabled=false > /tmp/no-webhook.yaml
+          if grep -Eq 'kind: (Certificate|Issuer|ValidatingWebhookConfiguration)|cert-manager.io|webhook-certs|containerPort: 9443' /tmp/no-webhook.yaml; then
+            echo "Webhook resources were rendered while webhook.enabled=false"
+            exit 1
+          fi
+          grep -A1 'name: ENABLE_WEBHOOK' /tmp/no-webhook.yaml | grep -q 'value: "false"'
 
   test-on-cluster:
     name: Cluster E2E Test
@@ -121,6 +129,11 @@ jobs:
           registry_port: 5001
           registry_enable_delete: true
 
+      - name: Install cert-manager
+        run: |
+          kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.21.0/cert-manager.yaml
+          kubectl wait --namespace cert-manager --for=condition=Available --timeout=2m deployment/cert-manager deployment/cert-manager-cainjector deployment/cert-manager-webhook
+
       - name: Run chart-testing (install)
         run: |
           version="${{ fromJSON(steps.goreleaser.outputs.metadata).version }}-amd64"
@@ -133,7 +146,36 @@ jobs:
 
           helm template test --namespace test test --set image.tag="$version" > rendered.yaml
           kubectl apply --server-side -f rendered.yaml --namespace test
-          kubectl wait --namespace test --for=condition=Available --timeout=20s deployment/test-shopware-operator
+          kubectl wait --namespace test --for=condition=Ready --timeout=60s certificate/test-serving-cert
+          kubectl wait --namespace test --for=condition=Available --timeout=60s deployment/test-shopware-operator
+
+          for _ in {1..30}; do
+            ca_bundle="$(kubectl get validatingwebhookconfiguration test-shopware-operator-validating-webhook -o jsonpath='{.webhooks[0].clientConfig.caBundle}')"
+            if [ -n "$ca_bundle" ]; then
+              break
+            fi
+            sleep 2
+          done
+          test -n "$ca_bundle"
+
+          webhook_validated=false
+          for _ in {1..30}; do
+            if kubectl apply --namespace test -f .github/testdata/invalid_store_override.yaml >/tmp/invalid-store.log 2>&1; then
+              echo "Store with an unknown container override field was accepted"
+              kubectl delete --namespace test -f .github/testdata/invalid_store_override.yaml --ignore-not-found=true
+              exit 1
+            fi
+            if grep -q "unknown field" /tmp/invalid-store.log; then
+              webhook_validated=true
+              break
+            fi
+            sleep 2
+          done
+          if [ "$webhook_validated" != "true" ]; then
+            echo "Webhook did not return the expected validation response"
+            cat /tmp/invalid-store.log
+            exit 1
+          fi
 
           kubectl get deployment --namespace test -o wide
           kubectl rollout status --namespace test deployment/test-shopware-operator --timeout=60s

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ test-chart: install
 
 .PHONY: run
 run: manifests generate zap-pretty ## Run a controller from your host.
-	LEADER_ELECT=false DISABLE_CHECKS=true LOG_LEVEL=debug LOG_FORMAT=zap-pretty go run ./cmd/main.go \
+	ENABLE_WEBHOOK=false LEADER_ELECT=false DISABLE_CHECKS=true LOG_LEVEL=debug LOG_FORMAT=zap-pretty go run ./cmd/main.go \
 		2>&1 | $(ZAP_PRETTY) --all
 
 

--- a/Makefile
+++ b/Makefile
@@ -256,10 +256,7 @@ resources: path manifests kustomize yq ## Create crd's and manager for a direct 
 	mkdir -p $(path)
 	$(KUSTOMIZE) build config/crd > $(path)/crd.yaml
 	$(KUSTOMIZE) build config/default > $(path)/manager.yaml
-	$(YQ) eval -i 'select(.kind == "Deployment") | .spec.template.spec.containers[0].image = "ghcr.io/shopware/shopware-operator:$(shell git describe --tags --abbrev=0)"' release/manager.yaml
-	echo "---" >> $(path)/manager.yaml
-	$(KUSTOMIZE) build config/rbac >> $(path)/manager.yaml
-	sed -i '/namespace: default/d' $(path)/manager.yaml
+	$(YQ) eval -i '(select(.kind == "Deployment").spec.template.spec.containers[0].image) = "ghcr.io/shopware/shopware-operator:$(shell git describe --tags --abbrev=0)"' $(path)/manager.yaml
 
 ##@ Build Dependencies
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ provided by MinIO.To run the operator within your cluster, execute the following
 NAMESPACE=default make run
 ```
 
+The local controller runs without the validating webhook because cert-manager only provisions its TLS certificate for in-cluster deployments. Admission validation remains enabled by default for Helm and Kustomize installations that include the webhook resources.
+
 > [!IMPORTANT]
 > Ensure that you are using the correct Kubernetes context before running the command.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This repository contains the Shopware Operator for Kubernetes. The Operator is a
 
 Below you find a descriptions how to deploy the Operator using `helm` or `kubectl`.
 
+The validating webhook is enabled by default and requires [cert-manager](https://cert-manager.io/) to issue and rotate its certificate. Helm installations can disable it with `--set webhook.enabled=false`; this also removes the cert-manager dependency, but container overrides will no longer receive webhook validation.
+
 ### Helm
 
 For a helm installation check out our [charts repository](https://github.com/shopware/helm-charts/tree/main/charts/shopware-operator)
@@ -27,14 +29,20 @@ For a helm installation check out our [charts repository](https://github.com/sho
    kubectl apply -f https://github.com/shopware/shopware-operator/releases/latest/download/crd.yaml --server-side
    ```
 
-2. Deploy the operator itself from `manager.yaml`:
+2. Deploy the operator itself from `manager.yaml` into the `default` namespace:
 
    ```sh
    kubectl apply -f https://github.com/shopware/shopware-operator/releases/latest/download/manager.yaml
    ```
 
 > [!IMPORTANT]
-> This will install the Operator in the default namespace, if you want to change this use `kubectl -n <namespace> apply -f ...`
+> The released `manager.yaml` wires its cluster-scoped webhook configuration to the `default` namespace. Use the Helm chart or a Kustomize overlay for installations in another namespace.
+
+For a source-based Kustomize installation without the webhook or cert-manager resources, use:
+
+```sh
+kubectl apply -k config/no-webhook
+```
 
 ## Local Development
 

--- a/api/v1/crd_schema_test.go
+++ b/api/v1/crd_schema_test.go
@@ -1,0 +1,30 @@
+package v1_test
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoreCRDUsesCompactContainerOverrideSchemas(t *testing.T) {
+	t.Parallel()
+
+	crd, err := os.ReadFile("../../config/crd/bases/shop.shopware.com_stores.yaml")
+	require.NoError(t, err)
+	require.Less(t, len(crd), 600*1024, "Store CRD must remain below 600 KiB")
+
+	for _, fieldName := range []string{
+		"adminDeploymentContainer",
+		"workerDeploymentContainer",
+		"storefrontDeploymentContainer",
+		"setupJobContainer",
+		"migrationJobContainer",
+	} {
+		assert.Contains(t, string(crd), fieldName+":")
+	}
+
+	assert.Equal(t, 5, bytes.Count(crd, []byte("x-kubernetes-preserve-unknown-fields: true")))
+}

--- a/api/v1/store.go
+++ b/api/v1/store.go
@@ -39,14 +39,24 @@ type StoreSpec struct {
 
 	Container ContainerSpec `json:"container"`
 
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:default={}
 	AdminDeploymentContainer ContainerMergeSpec `json:"adminDeploymentContainer,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:default={}
 	WorkerDeploymentContainer ContainerMergeSpec `json:"workerDeploymentContainer,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:default={}
 	StorefrontDeploymentContainer ContainerMergeSpec `json:"storefrontDeploymentContainer,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:default={}
 	SetupJobContainer ContainerMergeSpec `json:"setupJobContainer,omitempty"`
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:default={}
 	MigrationJobContainer ContainerMergeSpec `json:"migrationJobContainer,omitempty"`
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/go-logr/zapr"
 	shopv1 "github.com/shopware/shopware-operator/api/v1"
@@ -41,6 +42,7 @@ import (
 	"github.com/shopware/shopware-operator/internal/event"
 	"github.com/shopware/shopware-operator/internal/event/nats"
 	"github.com/shopware/shopware-operator/internal/logging"
+	shopwebhook "github.com/shopware/shopware-operator/internal/webhook"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	//+kubebuilder:scaffold:imports
 )
@@ -113,6 +115,13 @@ func main() {
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
+	}
+
+	if cfg.EnableWebhook {
+		mgr.GetWebhookServer().Register(
+			shopwebhook.StoreValidationPath,
+			&admission.Webhook{Handler: shopwebhook.StoreValidator{}},
+		)
 	}
 
 	nsClient := client.NewNamespacedClient(mgr.GetClient(), cfg.Namespace)

--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: serving-cert
+spec:
+  dnsNames:
+    - webhook-service.default.svc
+    - webhook-service.default.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: webhook-server-cert

--- a/config/certmanager/issuer.yaml
+++ b/config/certmanager/issuer.yaml
@@ -1,0 +1,6 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+spec:
+  selfSigned: {}

--- a/config/certmanager/kustomization.yaml
+++ b/config/certmanager/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - certificate.yaml
+  - issuer.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-#namespace: default
+namespace: default
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
@@ -17,11 +17,8 @@
 resources:
   - ../rbac
   - ../manager
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
-# crd/kustomization.yaml
-#- ../webhook
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-#- ../certmanager
+  - ../webhook
+  - ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
@@ -35,111 +32,5 @@ patches:
   - path: pull_secret_patch.yaml
     target:
       kind: Deployment
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
-# crd/kustomization.yaml
-#- path: manager_webhook_patch.yaml
-
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
-# Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
-# 'CERTMANAGER' needs to be enabled to use ca injection
-#- path: webhookcainjection_patch.yaml
-
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-# Uncomment the following replacements to add the cert-manager CA injection annotations
-#replacements:
-#  - source: # Add cert-manager annotation to ValidatingWebhookConfiguration, MutatingWebhookConfiguration and CRDs
-#      kind: Certificate
-#      group: cert-manager.io
-#      version: v1
-#      name: serving-cert # this name should match the one in certificate.yaml
-#      fieldPath: .metadata.namespace # namespace of the certificate CR
-#    targets:
-#      - select:
-#          kind: ValidatingWebhookConfiguration
-#        fieldPaths:
-#          - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#        options:
-#          delimiter: '/'
-#          index: 0
-#          create: true
-#      - select:
-#          kind: MutatingWebhookConfiguration
-#        fieldPaths:
-#          - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#        options:
-#          delimiter: '/'
-#          index: 0
-#          create: true
-#      - select:
-#          kind: CustomResourceDefinition
-#        fieldPaths:
-#          - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#        options:
-#          delimiter: '/'
-#          index: 0
-#          create: true
-#  - source:
-#      kind: Certificate
-#      group: cert-manager.io
-#      version: v1
-#      name: serving-cert # this name should match the one in certificate.yaml
-#      fieldPath: .metadata.name
-#    targets:
-#      - select:
-#          kind: ValidatingWebhookConfiguration
-#        fieldPaths:
-#          - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#        options:
-#          delimiter: '/'
-#          index: 1
-#          create: true
-#      - select:
-#          kind: MutatingWebhookConfiguration
-#        fieldPaths:
-#          - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#        options:
-#          delimiter: '/'
-#          index: 1
-#          create: true
-#      - select:
-#          kind: CustomResourceDefinition
-#        fieldPaths:
-#          - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#        options:
-#          delimiter: '/'
-#          index: 1
-#          create: true
-#  - source: # Add cert-manager annotation to the webhook Service
-#      kind: Service
-#      version: v1
-#      name: webhook-service
-#      fieldPath: .metadata.name # namespace of the service
-#    targets:
-#      - select:
-#          kind: Certificate
-#          group: cert-manager.io
-#          version: v1
-#        fieldPaths:
-#          - .spec.dnsNames.0
-#          - .spec.dnsNames.1
-#        options:
-#          delimiter: '.'
-#          index: 0
-#          create: true
-#  - source:
-#      kind: Service
-#      version: v1
-#      name: webhook-service
-#      fieldPath: .metadata.namespace # namespace of the service
-#    targets:
-#      - select:
-#          kind: Certificate
-#          group: cert-manager.io
-#          version: v1
-#        fieldPaths:
-#          - .spec.dnsNames.0
-#          - .spec.dnsNames.1
-#        options:
-#          delimiter: '.'
-#          index: 1
-#          create: true
+  - path: manager_webhook_patch.yaml
+  - path: webhookcainjection_patch.yaml

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: shopware-operator
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          ports:
+            - containerPort: 9443
+              name: webhook-server
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /tmp/k8s-webhook-server/serving-certs
+              name: webhook-certs
+              readOnly: true
+      volumes:
+        - name: webhook-certs
+          secret:
+            secretName: webhook-server-cert

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: default/serving-cert
+  name: validating-webhook-configuration

--- a/config/no-webhook/disable_webhook_patch.yaml
+++ b/config/no-webhook/disable_webhook_patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: shopware-operator
+spec:
+  template:
+    spec:
+      containers:
+        - env:
+            - name: ENABLE_WEBHOOK
+              value: "false"
+          name: manager

--- a/config/no-webhook/kustomization.yaml
+++ b/config/no-webhook/kustomization.yaml
@@ -1,0 +1,14 @@
+namespace: default
+
+resources:
+  - ../rbac
+  - ../manager
+
+patches:
+  - path: disable_webhook_patch.yaml
+  - target:
+      kind: Deployment
+    patch: |-
+      - op: add
+        path: /spec/template/spec/imagePullSecrets
+        value: [{ name: regcred }]

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+  - manifests.yaml
+  - service.yaml
+
+configurations:
+  - kustomizeconfig.yaml

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,3 +1,5 @@
+namespace: default
+
 resources:
   - manifests.yaml
   - service.yaml

--- a/config/webhook/kustomizeconfig.yaml
+++ b/config/webhook/kustomizeconfig.yaml
@@ -1,0 +1,13 @@
+nameReference:
+  - kind: Service
+    version: v1
+    fieldSpecs:
+      - kind: ValidatingWebhookConfiguration
+        group: admissionregistration.k8s.io
+        path: webhooks/clientConfig/service/name
+
+namespace:
+  - kind: ValidatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/namespace
+    create: true

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-shop-shopware-com-v1-store
+  failurePolicy: Fail
+  name: vstore.shopware.com
+  rules:
+  - apiGroups:
+    - shop.shopware.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - stores
+  sideEffects: None

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhook-service
+spec:
+  ports:
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    control-plane: shopware-operator

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	k8s.io/apimachinery v0.33.3
 	k8s.io/client-go v0.33.3
 	sigs.k8s.io/controller-runtime v0.20.3
+	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8
 )
 
 require (
@@ -102,7 +103,6 @@ require (
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
 	k8s.io/utils v0.0.0-20241210054802-24370beab758 // indirect
 	sigs.k8s.io/gateway-api v1.2.1
-	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/helm/README.md
+++ b/helm/README.md
@@ -6,6 +6,7 @@ Useful links
 ## Pre-requisites
 * Kubernetes 1.28+
 * Helm v3
+* cert-manager, unless the validating webhook is disabled
 
 # Disclaimer
 
@@ -37,6 +38,12 @@ To install the chart using a dedicated namespace is recommended:
 ```sh
 helm repo add shopware https://shopware.github.io/helm-charts/
 helm install my-operator shopware/operator --namespace my-namespace --create-namespace
+```
+
+To install without cert-manager, disable container-override validation:
+
+```sh
+helm install my-operator shopware/operator --namespace my-namespace --create-namespace --set webhook.enabled=false
 ```
 
 Checkout the [values.yaml](values.yaml) file to modify the operator deployment.

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -79,6 +79,8 @@ spec:
           value: "{{ .Values.logFormat | default "json" }}"
         - name: DISABLE_CHECKS
           value: "{{ .Values.disableChecks | default "false" }}"
+        - name: ENABLE_WEBHOOK
+          value: "{{ .Values.webhook.enabled }}"
         - name: SUCCESSFUL_CR_CLEANUP_GRACE_PERIOD
           value: "{{ .Values.successfulCRCleanupGracePeriod | default "1h" }}"
         {{- if and (hasKey .Values "events") (hasKey .Values.events "nats") (.Values.events.nats.enable) }}
@@ -114,6 +116,12 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
+        {{- if .Values.webhook.enabled }}
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        {{- end }}
         resources:
           {{- with .Values.resources }}
               {{- toYaml . | nindent 10 }}
@@ -124,6 +132,11 @@ spec:
             drop:
             - ALL
         volumeMounts:
+          {{- if .Values.webhook.enabled }}
+          - mountPath: /tmp/k8s-webhook-server/serving-certs
+            name: webhook-certs
+            readOnly: true
+          {{- end }}
           {{- if and (hasKey .Values "events") (hasKey .Values.events "nats") (.Values.events.nats.enable) (hasKey .Values.events.nats "nkeyRef") }}
           - mountPath: /secrets
             name: nkey
@@ -139,6 +152,11 @@ spec:
       serviceAccountName: '{{ .Release.Name }}-shopware-operator'
       terminationGracePeriodSeconds: 10
       volumes:
+        {{- if .Values.webhook.enabled }}
+        - name: webhook-certs
+          secret:
+            secretName: '{{ .Release.Name }}-webhook-server-cert'
+        {{- end }}
         {{- if and (hasKey .Values "events") (hasKey .Values.events "nats") (.Values.events.nats.enable) (hasKey .Values.events.nats "nkeyRef") }}
         - name: nkey
           secret:

--- a/helm/templates/webhook.yaml
+++ b/helm/templates/webhook.yaml
@@ -1,0 +1,65 @@
+{{- if and (not .Values.crds.installOnly) .Values.webhook.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: '{{ .Release.Name }}-webhook-service'
+  namespace: {{ .Release.Namespace }}
+spec:
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    control-plane: shopware-operator
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: '{{ .Release.Name }}-selfsigned-issuer'
+  namespace: {{ .Release.Namespace }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: '{{ .Release.Name }}-serving-cert'
+  namespace: {{ .Release.Namespace }}
+spec:
+  dnsNames:
+  - '{{ .Release.Name }}-webhook-service.{{ .Release.Namespace }}.svc'
+  - '{{ .Release.Name }}-webhook-service.{{ .Release.Namespace }}.svc.cluster.local'
+  issuerRef:
+    kind: Issuer
+    name: '{{ .Release.Name }}-selfsigned-issuer'
+  secretName: '{{ .Release.Name }}-webhook-server-cert'
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ .Release.Name }}-serving-cert'
+  name: '{{ .Release.Name }}-shopware-operator-validating-webhook'
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: '{{ .Release.Name }}-webhook-service'
+      namespace: {{ .Release.Namespace }}
+      path: /validate-shop-shopware-com-v1-store
+  failurePolicy: Fail
+  name: 'vstore.{{ .Release.Name }}.shopware.com'
+  rules:
+  - apiGroups:
+    - shop.shopware.com
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - stores
+  sideEffects: None
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -17,6 +17,11 @@ crds:
   # This will install only the crd's
   installOnly: false
 
+# Validates the schemaless Store container override fields. When enabled,
+# cert-manager must be installed in the cluster.
+webhook:
+  enabled: true
+
 # rbac: settings for deployer RBAC creation
 rbac:
   # rbac.create: if false, RBAC resources should be in place

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,6 +68,7 @@ type StoreConfig struct {
 	ProbeAddr   string `env:"HEALTH_PROBE_BIND_ADDRESS, default=:8081"`
 
 	EnableLeaderElection bool   `env:"LEADER_ELECT, default=true"`
+	EnableWebhook        bool   `env:"ENABLE_WEBHOOK, default=true"`
 	DisableChecks        bool   `env:"DISABLE_CHECKS, default=false"`
 	Namespace            string `env:"NAMESPACE, default=default"`
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoreConfigEnablesWebhookByDefault(t *testing.T) {
+	previousValue, wasSet := os.LookupEnv("ENABLE_WEBHOOK")
+	require.NoError(t, os.Unsetenv("ENABLE_WEBHOOK"))
+	t.Cleanup(func() {
+		if wasSet {
+			require.NoError(t, os.Setenv("ENABLE_WEBHOOK", previousValue))
+			return
+		}
+		require.NoError(t, os.Unsetenv("ENABLE_WEBHOOK"))
+	})
+
+	cfg, err := LoadStoreConfig(context.Background())
+	require.NoError(t, err)
+	require.True(t, cfg.EnableWebhook)
+}
+
+func TestStoreConfigCanDisableWebhook(t *testing.T) {
+	t.Setenv("ENABLE_WEBHOOK", "false")
+
+	cfg, err := LoadStoreConfig(context.Background())
+	require.NoError(t, err)
+	require.False(t, cfg.EnableWebhook)
+}

--- a/internal/webhook/store_validator.go
+++ b/internal/webhook/store_validator.go
@@ -1,0 +1,92 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	shopv1 "github.com/shopware/shopware-operator/api/v1"
+	admissionv1 "k8s.io/api/admission/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	kjson "sigs.k8s.io/json"
+)
+
+const StoreValidationPath = "/validate-shop-shopware-com-v1-store"
+
+var storeContainerOverrideFields = []string{
+	"adminDeploymentContainer",
+	"workerDeploymentContainer",
+	"storefrontDeploymentContainer",
+	"setupJobContainer",
+	"migrationJobContainer",
+}
+
+// +kubebuilder:webhook:path=/validate-shop-shopware-com-v1-store,mutating=false,failurePolicy=fail,sideEffects=None,groups=shop.shopware.com,resources=stores,verbs=create;update,versions=v1,name=vstore.shopware.com,admissionReviewVersions=v1
+
+// StoreValidator validates the schemaless container override fields against
+// their strongly typed Go representation.
+type StoreValidator struct{}
+
+func (StoreValidator) Handle(_ context.Context, req admission.Request) admission.Response {
+	if req.Operation != admissionv1.Create && req.Operation != admissionv1.Update {
+		return admission.Allowed("")
+	}
+
+	var store shopv1.Store
+	strictErrors, err := kjson.UnmarshalStrict(
+		req.Object.Raw,
+		&store,
+		kjson.DisallowDuplicateFields,
+		kjson.DisallowUnknownFields,
+	)
+	if err != nil {
+		return admission.Denied(fmt.Sprintf("invalid Store JSON: %v", err))
+	}
+
+	errors := make([]string, 0, len(strictErrors)+1)
+	for _, strictErr := range strictErrors {
+		errors = append(errors, strictErr.Error())
+	}
+	errors = append(errors, validateExplicitOverrideRules(req.Object.Raw)...)
+
+	if len(errors) > 0 {
+		return admission.Denied("invalid container override: " + strings.Join(errors, "; "))
+	}
+
+	return admission.Allowed("")
+}
+
+func validateExplicitOverrideRules(raw []byte) []string {
+	var object struct {
+		Spec map[string]json.RawMessage `json:"spec"`
+	}
+	if err := json.Unmarshal(raw, &object); err != nil {
+		return nil // The strict decoder reports syntax and type errors.
+	}
+
+	var errors []string
+	for _, fieldName := range storeContainerOverrideFields {
+		overrideRaw, found := object.Spec[fieldName]
+		if !found {
+			continue
+		}
+
+		var override map[string]json.RawMessage
+		if err := json.Unmarshal(overrideRaw, &override); err != nil {
+			continue // The strict decoder reports a non-object value.
+		}
+
+		imageRaw, found := override["image"]
+		if !found {
+			continue
+		}
+
+		var image string
+		if err := json.Unmarshal(imageRaw, &image); err == nil && image == "" {
+			errors = append(errors, fmt.Sprintf("spec.%s.image must not be empty", fieldName))
+		}
+	}
+
+	return errors
+}

--- a/internal/webhook/store_validator_test.go
+++ b/internal/webhook/store_validator_test.go
@@ -1,0 +1,98 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func TestStoreValidatorAcceptsContainerOverrides(t *testing.T) {
+	t.Parallel()
+
+	for _, fieldName := range storeContainerOverrideFields {
+		t.Run(fieldName, func(t *testing.T) {
+			t.Parallel()
+
+			raw := fmt.Sprintf(`{
+  "apiVersion":"shop.shopware.com/v1",
+  "kind":"Store",
+  "metadata":{"name":"test","namespace":"default"},
+  "spec":{"%s":{"image":"example.com/shopware:latest","replicas":2,"extraEnvs":[{"name":"APP_ENV","value":"prod"}],"resources":{"requests":{"cpu":"100m"}}}}
+}`, fieldName)
+
+			response := validateStore(t, admissionv1.Create, raw)
+			require.True(t, response.Allowed, response.Result.Message)
+		})
+	}
+}
+
+func TestStoreValidatorRejectsInvalidOverrides(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		raw     string
+		message string
+	}{
+		"unknown field": {
+			raw:     `{"spec":{"workerDeploymentContainer":{"unknownField":true}}}`,
+			message: "unknown field",
+		},
+		"unknown nested field": {
+			raw:     `{"spec":{"workerDeploymentContainer":{"extraEnvs":[{"name":"APP_ENV","unknownField":true}]}}}`,
+			message: "unknown field",
+		},
+		"duplicate field": {
+			raw:     `{"spec":{"workerDeploymentContainer":{"replicas":1,"replicas":2}}}`,
+			message: "duplicate field",
+		},
+		"wrong field type": {
+			raw:     `{"spec":{"workerDeploymentContainer":{"replicas":"two"}}}`,
+			message: "cannot unmarshal",
+		},
+		"empty image": {
+			raw:     `{"spec":{"workerDeploymentContainer":{"image":""}}}`,
+			message: "spec.workerDeploymentContainer.image must not be empty",
+		},
+		"malformed JSON": {
+			raw:     `{"spec":`,
+			message: "invalid Store JSON",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			response := validateStore(t, admissionv1.Update, test.raw)
+			require.False(t, response.Allowed)
+			assert.Contains(t, strings.ToLower(response.Result.Message), strings.ToLower(test.message))
+		})
+	}
+}
+
+func TestStoreValidatorIgnoresOtherOperations(t *testing.T) {
+	t.Parallel()
+
+	response := validateStore(t, admissionv1.Delete, `{"not":"a store"}`)
+	require.True(t, response.Allowed, response.Result.Message)
+}
+
+func validateStore(t *testing.T, operation admissionv1.Operation, raw string) admission.Response {
+	t.Helper()
+
+	return (StoreValidator{}).Handle(context.Background(), admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: operation,
+			Object: runtime.RawExtension{
+				Raw: []byte(raw),
+			},
+		},
+	})
+}


### PR DESCRIPTION
To lower the size of the created crds we introduce
a validating webhook that is used to validate the
overwrites.

The validating webhook requires cert-manager installed in the cluster.
The size of the created crds will be shrinked from 2.5 to 0.5MB.
