### PR TITLE
fix: worker restart after 5 minutes

### DIFF
--- a/internal/deployment/worker.go
+++ b/internal/deployment/worker.go
@@ -82,9 +82,10 @@ func WorkerDeployment(store v1.Store) *appsv1.Deployment {
 	envs := util.MergeEnv(store.GetEnv(), containerSpec.ExtraEnvs)
 
 	// Set PHP_MEMORY_LIMIT to 90% of the container memory limit
+	phpMemoryLimitMiB := 0
 	if containerSpec.Resources.Limits.Memory() != nil && containerSpec.Resources.Limits.Memory().Value() != 0 {
 		memoryLimitMiB := containerSpec.Resources.Limits.Memory().Value() / (1024 * 1024)
-		phpMemoryLimitMiB := int(math.Floor(float64(memoryLimitMiB) * 0.9))
+		phpMemoryLimitMiB = int(math.Floor(float64(memoryLimitMiB) * 0.9))
 		envs = util.MergeEnv(envs, []corev1.EnvVar{
 			{
 				Name:  "PHP_MEMORY_LIMIT",
@@ -93,6 +94,21 @@ func WorkerDeployment(store v1.Store) *appsv1.Deployment {
 		})
 	}
 
+	consume := "bin/console messenger:consume --all --time-limit=300"
+	if phpMemoryLimitMiB > 0 {
+		consume += fmt.Sprintf(" --memory-limit=%dM", phpMemoryLimitMiB)
+	}
+	workerScript := fmt.Sprintf(
+		`trap 'kill -TERM "$child" 2>/dev/null' TERM INT
+while true; do
+  %s &
+  child=$!
+  wait "$child"
+  [ $? -gt 128 ] && exit 0
+done`,
+		consume,
+	)
+
 	containers := append(util.DefaultContainerSecurityContexts(containerSpec.ExtraContainers), corev1.Container{
 		Name:            appName,
 		Image:           containerSpec.Image,
@@ -100,14 +116,11 @@ func WorkerDeployment(store v1.Store) *appsv1.Deployment {
 		Env:             envs,
 		SecurityContext: util.RestrictedContainerSecurityContext(),
 		Command: []string{
-			"bin/console",
+			"/bin/sh",
+			"-c",
 		},
 		Args: []string{
-			"messenger:consume",
-			"async",
-			"low_priority",
-			"failed",
-			"scheduler_shopware",
+			workerScript,
 		},
 		VolumeMounts: containerSpec.VolumeMounts,
 		Ports: []corev1.ContainerPort{

--- a/internal/deployment/worker_test.go
+++ b/internal/deployment/worker_test.go
@@ -216,14 +216,35 @@ func TestWorkerDeployment(t *testing.T) {
 		container := result.Spec.Template.Spec.Containers[0]
 
 		// Verify worker command and args
-		assert.Equal(t, []string{"bin/console"}, container.Command)
-		assert.Equal(t, []string{
-			"messenger:consume",
-			"async",
-			"low_priority",
-			"failed",
-			"scheduler_shopware",
-		}, container.Args)
+		assert.Equal(t, []string{"/bin/sh", "-c"}, container.Command)
+		assert.Len(t, container.Args, 1)
+		assert.Contains(t, container.Args[0], "bin/console messenger:consume --all --time-limit=300")
+		assert.NotContains(t, container.Args[0], "--memory-limit")
+		assert.Contains(t, container.Args[0], `trap 'kill -TERM "$child"`)
 		assert.Equal(t, "shopware-worker", container.Name)
+	})
+
+	t.Run("test worker memory limit flag", func(t *testing.T) {
+		store := v1.Store{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-store",
+				Namespace: "test",
+			},
+			Spec: v1.StoreSpec{
+				Container: v1.ContainerSpec{
+					Image: "shopware:latest",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("1000Mi"),
+						},
+					},
+				},
+			},
+		}
+
+		result := deployment.WorkerDeployment(store)
+		container := result.Spec.Template.Spec.Containers[0]
+
+		assert.Contains(t, container.Args[0], "--memory-limit=900M")
 	})
 }


### PR DESCRIPTION
We use a small bash script which restarts the worker so we don't get a
crashloop backoff. Currently all queues are consumed, scaling will be
done later
