### PR TITLE
fix: preserve autoscaled deployment replicas

### DIFF
--- a/internal/controller/store_controller.go
+++ b/internal/controller/store_controller.go
@@ -142,6 +142,7 @@ func (r *StoreReconciler) findStoreForReconcile(
 //+kubebuilder:rbac:groups="",namespace=default,resources=services,verbs=get;list;watch;create;patch
 //+kubebuilder:rbac:groups="",namespace=default,resources=pods,verbs=get;list;watch;
 //+kubebuilder:rbac:groups="apps",namespace=default,resources=deployments,verbs=get;list;watch;create;patch
+//+kubebuilder:rbac:groups="autoscaling",namespace=default,resources=horizontalpodautoscalers,verbs=get;list;watch;create;patch
 //+kubebuilder:rbac:groups="batch",namespace=default,resources=jobs,verbs=get;list;watch;create;delete
 //+kubebuilder:rbac:groups="networking.k8s.io",namespace=default,resources=ingresses,verbs=get;list;watch;create;patch
 //+kubebuilder:rbac:groups="gateway.networking.k8s.io",namespace=default,resources=httproutes,verbs=get;list;watch;create;patch
@@ -489,7 +490,7 @@ func (r *StoreReconciler) reconcileDeployment(ctx context.Context, store *v1.Sto
 	}
 
 	for _, obj := range objs {
-		if changed, err = k8s.HasObjectChanged(ctx, r.Client, obj); err != nil {
+		if changed, err = k8s.HasDeploymentChanged(ctx, r.Client, obj); err != nil {
 			return fmt.Errorf("reconcile unready deployment: %w", err)
 		}
 

--- a/internal/k8s/utils.go
+++ b/internal/k8s/utils.go
@@ -373,16 +373,78 @@ func EnsureDeployment(
 		if k8serrors.IsNotFound(err) {
 			return EnsureObjectWithHash(ctx, cl, owner, deployment, s)
 		}
-		return errors.Wrap(err, "get object")
+		return errors.Wrap(err, "get deployment")
 	}
 
-	return EnsureObjectWithHash(ctx, cl, owner, deployment, s)
+	autoscaled, err := isDeploymentAutoscaled(ctx, cl, deployment)
+	if err != nil {
+		return errors.Wrap(err, "check deployment autoscaling")
+	}
+	if !autoscaled {
+		return EnsureObjectWithHash(ctx, cl, owner, deployment, s)
+	}
+
+	// The HorizontalPodAutoscaler owns the scale subresource. Keep its current
+	// value while reconciling the rest of the Deployment.
+	deployment.Spec.Replicas = oldDep.Spec.Replicas
+	return ensureObjectWithHash(ctx, cl, owner, deployment, deploymentHashObject(deployment), s)
+}
+
+func isDeploymentAutoscaled(
+	ctx context.Context,
+	cl client.Client,
+	deployment *appsv1.Deployment,
+) (bool, error) {
+	hpas := &autoscalingv2.HorizontalPodAutoscalerList{}
+	if err := cl.List(ctx, hpas, client.InNamespace(deployment.Namespace)); err != nil {
+		return false, errors.Wrap(err, "list horizontal pod autoscalers")
+	}
+
+	for _, hpa := range hpas.Items {
+		target := hpa.Spec.ScaleTargetRef
+		if target.APIVersion == "apps/v1" && target.Kind == "Deployment" && target.Name == deployment.Name {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func HasDeploymentChanged(
+	ctx context.Context,
+	cl client.Client,
+	deployment *appsv1.Deployment,
+) (bool, error) {
+	autoscaled, err := isDeploymentAutoscaled(ctx, cl, deployment)
+	if err != nil {
+		return true, err
+	}
+	if autoscaled {
+		return hasObjectChanged(ctx, cl, deployment, deploymentHashObject(deployment))
+	}
+
+	return HasObjectChanged(ctx, cl, deployment)
+}
+
+func deploymentHashObject(deployment *appsv1.Deployment) *appsv1.Deployment {
+	deploymentCopy := deployment.DeepCopy()
+	deploymentCopy.Spec.Replicas = nil
+	return deploymentCopy
 }
 
 func HasObjectChanged(
 	ctx context.Context,
 	cl client.Client,
 	obj client.Object,
+) (bool, error) {
+	return hasObjectChanged(ctx, cl, obj, obj)
+}
+
+func hasObjectChanged(
+	ctx context.Context,
+	cl client.Client,
+	obj client.Object,
+	hashObject runtime.Object,
 ) (bool, error) {
 	if obj.GetAnnotations() == nil {
 		obj.SetAnnotations(make(map[string]string))
@@ -392,7 +454,7 @@ func HasObjectChanged(
 	delete(objAnnotations, "shopware.com/last-config-hash")
 	obj.SetAnnotations(objAnnotations)
 
-	hash, err := ObjectHash(obj)
+	hash, err := ObjectHash(hashObject)
 	if err != nil {
 		return true, errors.Wrap(err, "calculate object hash")
 	}
@@ -442,6 +504,17 @@ func EnsureObjectWithHash(
 	obj client.Object,
 	s *runtime.Scheme,
 ) error {
+	return ensureObjectWithHash(ctx, cl, owner, obj, obj, s)
+}
+
+func ensureObjectWithHash(
+	ctx context.Context,
+	cl client.Client,
+	owner metav1.Object,
+	obj client.Object,
+	hashObject runtime.Object,
+	s *runtime.Scheme,
+) error {
 	if owner != nil {
 		if err := controllerutil.SetControllerReference(owner, obj, s); err != nil {
 			return errors.Wrapf(err, "set controller reference to %s/%s",
@@ -458,7 +531,7 @@ func EnsureObjectWithHash(
 	delete(objAnnotations, "shopware.com/last-config-hash")
 	obj.SetAnnotations(objAnnotations)
 
-	hash, err := ObjectHash(obj)
+	hash, err := ObjectHash(hashObject)
 	if err != nil {
 		return errors.Wrap(err, "calculate object hash")
 	}

--- a/internal/k8s/utils_test.go
+++ b/internal/k8s/utils_test.go
@@ -1,0 +1,132 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestEnsureDeploymentPreservesAutoscaledReplicas(t *testing.T) {
+	ctx := context.Background()
+	scheme := newScheme(t)
+
+	existing := testDeployment(6, "shopware:v1")
+	setDeploymentHash(t, existing, true)
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "keda-hpa-store-storefront",
+			Namespace: "shop",
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "store-storefront",
+			},
+		},
+	}
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing, hpa).Build()
+	desired := testDeployment(2, "shopware:v2")
+
+	changed, err := HasDeploymentChanged(ctx, client, desired)
+	require.NoError(t, err)
+	assert.True(t, changed)
+
+	require.NoError(t, EnsureDeployment(ctx, client, nil, desired, scheme, true))
+
+	updated := &appsv1.Deployment{}
+	require.NoError(t, client.Get(ctx, objectKey(existing), updated))
+	assert.Equal(t, int32(6), *updated.Spec.Replicas)
+	assert.Equal(t, "shopware:v2", updated.Spec.Template.Spec.Containers[0].Image)
+
+	updated.Spec.Replicas = ptr.To(int32(5))
+	require.NoError(t, client.Update(ctx, updated))
+
+	changed, err = HasDeploymentChanged(ctx, client, testDeployment(2, "shopware:v2"))
+	require.NoError(t, err)
+	assert.False(t, changed)
+}
+
+func TestEnsureDeploymentAppliesConfiguredReplicasWithoutAutoscaler(t *testing.T) {
+	ctx := context.Background()
+	scheme := newScheme(t)
+
+	existing := testDeployment(6, "shopware:v1")
+	setDeploymentHash(t, existing, false)
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
+	desired := testDeployment(2, "shopware:v2")
+
+	changed, err := HasDeploymentChanged(ctx, client, desired)
+	require.NoError(t, err)
+	assert.True(t, changed)
+
+	require.NoError(t, EnsureDeployment(ctx, client, nil, desired, scheme, true))
+
+	updated := &appsv1.Deployment{}
+	require.NoError(t, client.Get(ctx, objectKey(existing), updated))
+	assert.Equal(t, int32(2), *updated.Spec.Replicas)
+	assert.Equal(t, "shopware:v2", updated.Spec.Template.Spec.Containers[0].Image)
+}
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, autoscalingv2.AddToScheme(scheme))
+	return scheme
+}
+
+func testDeployment(replicas int32, image string) *appsv1.Deployment {
+	const name = "store-storefront"
+
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "shop",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.To(replicas),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": name},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": name},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "shopware",
+						Image: image,
+					}},
+				},
+			},
+		},
+	}
+}
+
+func setDeploymentHash(t *testing.T, deployment *appsv1.Deployment, autoscaled bool) {
+	t.Helper()
+
+	hashObject := runtime.Object(deployment)
+	if autoscaled {
+		hashObject = deploymentHashObject(deployment)
+	}
+	hash, err := ObjectHash(hashObject)
+	require.NoError(t, err)
+	deployment.Annotations = map[string]string{"shopware.com/last-config-hash": hash}
+}
+
+func objectKey(object client.Object) client.ObjectKey {
+	return client.ObjectKeyFromObject(object)
+}


### PR DESCRIPTION
This pull request introduces improved handling for Kubernetes Deployments that are managed by HorizontalPodAutoscalers (HPAs). The main goal is to ensure that when a Deployment is autoscaled, the controller preserves the replica count set by the HPA rather than overwriting it during reconciliation. The changes also add targeted unit tests to verify this behavior.

**Deployment & Autoscaling Logic Improvements:**

* The `EnsureDeployment` and `HasDeploymentChanged` functions now detect if a Deployment is managed by an HPA. If so, they preserve the current replica count and only reconcile other changes, preventing the controller from fighting with the autoscaler. [[1]](diffhunk://#diff-dd419206fba052c254bc3328785544c0c44bff0cd84fef9cfe8714dd9eb99602L376-R447) [[2]](diffhunk://#diff-dd419206fba052c254bc3328785544c0c44bff0cd84fef9cfe8714dd9eb99602L395-R457) [[3]](diffhunk://#diff-dd419206fba052c254bc3328785544c0c44bff0cd84fef9cfe8714dd9eb99602R506-R516) [[4]](diffhunk://#diff-dd419206fba052c254bc3328785544c0c44bff0cd84fef9cfe8714dd9eb99602L461-R534)

* A new helper function, `isDeploymentAutoscaled`, checks for HPAs targeting a Deployment, and `deploymentHashObject` ensures the hash used for change detection ignores the replica count when autoscaled.

* The `StoreReconciler` now uses `HasDeploymentChanged` instead of the generic `HasObjectChanged` to benefit from the autoscaling-aware logic.

**RBAC Permissions:**

* The RBAC rules in `store_controller.go` are updated to include permissions for managing `horizontalpodautoscalers` in the default namespace, ensuring the controller can list and watch HPAs.

**Testing:**

* New unit tests in `internal/k8s/utils_test.go` verify that:
  - For autoscaled Deployments, the replica count is preserved during reconciliation.
  - For non-autoscaled Deployments, the replica count is updated as configured.