### PR TITLE
fix webhook multi install

### DIFF
--- a/.github/testdata/invalid_store_override.yaml
+++ b/.github/testdata/invalid_store_override.yaml
@@ -22,5 +22,5 @@ spec:
     adapter: builtin
   worker:
     adapter: builtin
-  workerDeploymentContainer:
-    unexpectedField: true
+  adminDeploymentContainer:
+    unknownField: bar

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -150,7 +150,7 @@ jobs:
           kubectl wait --namespace test --for=condition=Available --timeout=60s deployment/test-shopware-operator
 
           for _ in {1..30}; do
-            ca_bundle="$(kubectl get validatingwebhookconfiguration test-shopware-operator-validating-webhook -o jsonpath='{.webhooks[0].clientConfig.caBundle}')"
+            ca_bundle="$(kubectl get validatingwebhookconfiguration test-test-shopware-operator-validating-webhook -o jsonpath='{.webhooks[0].clientConfig.caBundle}')"
             if [ -n "$ca_bundle" ]; then
               break
             fi

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ Below you find a descriptions how to deploy the Operator using `helm` or `kubect
 
 The validating webhook is enabled by default and requires [cert-manager](https://cert-manager.io/) to issue and rotate its certificate. Helm installations can disable it with `--set webhook.enabled=false`; this also removes the cert-manager dependency, but container overrides will no longer receive webhook validation.
 
+For Helm installations, the webhook validates `Store` resources only in the
+operator's release namespace by default. This allows multiple operator versions
+to be installed in separate namespaces without their webhooks affecting one
+another. A custom `webhook.namespaceSelector` can be configured when an operator
+needs to manage additional namespaces. The default value `{}` means “use the
+operator's release namespace”; to select all namespaces explicitly, configure
+`namespaceSelector.matchExpressions: []`.
+
 ### Helm
 
 For a helm installation check out our [charts repository](https://github.com/shopware/helm-charts/tree/main/charts/shopware-operator)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -120,7 +120,7 @@ func main() {
 	if cfg.EnableWebhook {
 		mgr.GetWebhookServer().Register(
 			shopwebhook.StoreValidationPath,
-			&admission.Webhook{Handler: shopwebhook.StoreValidator{}},
+			&admission.Webhook{Handler: shopwebhook.StoreValidator{Logger: logger}},
 		)
 	}
 

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -33,6 +33,7 @@ spec:
         {{- end }}
       labels:
         control-plane: shopware-operator
+        shopware.com/operator-release: '{{ .Release.Name }}'
         {{- with .Values.podLabels }}
             {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/helm/templates/webhook.yaml
+++ b/helm/templates/webhook.yaml
@@ -12,6 +12,7 @@ spec:
     targetPort: 9443
   selector:
     control-plane: shopware-operator
+    shopware.com/operator-release: '{{ .Release.Name }}'
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer
@@ -40,7 +41,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ .Release.Name }}-serving-cert'
-  name: '{{ .Release.Name }}-shopware-operator-validating-webhook'
+  name: '{{ .Release.Name }}-{{ .Release.Namespace }}-shopware-operator-validating-webhook'
 webhooks:
 - admissionReviewVersions:
   - v1
@@ -50,7 +51,7 @@ webhooks:
       namespace: {{ .Release.Namespace }}
       path: /validate-shop-shopware-com-v1-store
   failurePolicy: Fail
-  name: 'vstore.{{ .Release.Name }}.shopware.com'
+  name: 'vstore.{{ .Release.Name }}.{{ .Release.Namespace }}.shopware.com'
   rules:
   - apiGroups:
     - shop.shopware.com
@@ -61,5 +62,13 @@ webhooks:
     - UPDATE
     resources:
     - stores
+  {{- if .Values.webhook.namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml .Values.webhook.namespaceSelector | nindent 4 }}
+  {{- else }}
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: '{{ .Release.Namespace }}'
+  {{- end }}
   sideEffects: None
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -21,6 +21,12 @@ crds:
 # cert-manager must be installed in the cluster.
 webhook:
   enabled: true
+  # An empty map ({}) uses the operator's release namespace by default.
+  # To validate Stores in all namespaces, use:
+  # namespaceSelector:
+  #   matchExpressions: []
+  # Or set this to a Kubernetes namespaceSelector to manage a custom set of namespaces.
+  namespaceSelector: {}
 
 # rbac: settings for deployer RBAC creation
 rbac:

--- a/internal/webhook/store_validator.go
+++ b/internal/webhook/store_validator.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	shopv1 "github.com/shopware/shopware-operator/api/v1"
+	"github.com/shopware/shopware-operator/internal/logging"
+	"go.uber.org/zap"
 	admissionv1 "k8s.io/api/admission/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	kjson "sigs.k8s.io/json"
@@ -26,27 +28,43 @@ var storeContainerOverrideFields = []string{
 
 // StoreValidator validates the schemaless container override fields against
 // their strongly typed Go representation.
-type StoreValidator struct{}
+type StoreValidator struct {
+	Logger *zap.SugaredLogger
+}
 
-func (StoreValidator) Handle(_ context.Context, req admission.Request) admission.Response {
+func (validator StoreValidator) Handle(ctx context.Context, req admission.Request) (response admission.Response) {
+	logger := validator.Logger
+	if logger == nil {
+		logger = logging.FromContext(ctx)
+	}
+	logger.Infow("Store validation webhook invoked",
+		"operation", req.Operation,
+		"namespace", req.Namespace,
+		"name", req.Name,
+		"group", req.Resource.Group,
+		"version", req.Resource.Version,
+		"resource", req.Resource.Resource,
+		"subresource", req.SubResource,
+	)
+	defer func() {
+		fields := []interface{}{"allowed", response.Allowed}
+		if response.Result != nil {
+			fields = append(fields,
+				"reason", response.Result.Reason,
+				"code", response.Result.Code,
+				"message", response.Result.Message,
+			)
+		}
+		logger.Infow("Store validation webhook completed", fields...)
+	}()
+
 	if req.Operation != admissionv1.Create && req.Operation != admissionv1.Update {
 		return admission.Allowed("")
 	}
 
-	var store shopv1.Store
-	strictErrors, err := kjson.UnmarshalStrict(
-		req.Object.Raw,
-		&store,
-		kjson.DisallowDuplicateFields,
-		kjson.DisallowUnknownFields,
-	)
-	if err != nil {
-		return admission.Denied(fmt.Sprintf("invalid Store JSON: %v", err))
-	}
-
-	errors := make([]string, 0, len(strictErrors)+1)
-	for _, strictErr := range strictErrors {
-		errors = append(errors, strictErr.Error())
+	errors := validateContainerOverrides(req.Object.Raw)
+	if len(errors) > 0 && strings.HasPrefix(errors[0], "invalid Store JSON:") {
+		return admission.Denied(errors[0])
 	}
 	errors = append(errors, validateExplicitOverrideRules(req.Object.Raw)...)
 
@@ -55,6 +73,56 @@ func (StoreValidator) Handle(_ context.Context, req admission.Request) admission
 	}
 
 	return admission.Allowed("")
+}
+
+func validateContainerOverrides(raw []byte) []string {
+	var object map[string]json.RawMessage
+	strictErrors, err := kjson.UnmarshalStrict(raw, &object, kjson.DisallowDuplicateFields)
+	if err != nil {
+		return []string{fmt.Sprintf("invalid Store JSON: %v", err)}
+	}
+
+	var errors []string
+	for _, strictErr := range strictErrors {
+		errors = append(errors, strictErr.Error())
+	}
+
+	specRaw, found := object["spec"]
+	if !found || len(specRaw) == 0 {
+		return errors
+	}
+
+	var spec map[string]json.RawMessage
+	specStrictErrors, err := kjson.UnmarshalStrict(specRaw, &spec, kjson.DisallowDuplicateFields)
+	if err != nil {
+		return append(errors, fmt.Sprintf("invalid Store JSON: %v", err))
+	}
+	for _, strictErr := range specStrictErrors {
+		errors = append(errors, strictErr.Error())
+	}
+
+	for _, fieldName := range storeContainerOverrideFields {
+		overrideRaw, found := spec[fieldName]
+		if !found {
+			continue
+		}
+
+		var override shopv1.ContainerMergeSpec
+		strictErrors, err := kjson.UnmarshalStrict(
+			overrideRaw,
+			&override,
+			kjson.DisallowDuplicateFields,
+			kjson.DisallowUnknownFields,
+		)
+		if err != nil {
+			errors = append(errors, err.Error())
+		}
+		for _, strictErr := range strictErrors {
+			errors = append(errors, strictErr.Error())
+		}
+	}
+
+	return errors
 }
 
 func validateExplicitOverrideRules(raw []byte) []string {

--- a/internal/webhook/store_validator_test.go
+++ b/internal/webhook/store_validator_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -33,6 +34,41 @@ func TestStoreValidatorAcceptsContainerOverrides(t *testing.T) {
 	}
 }
 
+func TestStoreValidatorAllowsUnknownTopLevelStoreFields(t *testing.T) {
+	t.Parallel()
+
+	response := validateStore(t, admissionv1.Create, `{
+	"apiVersion":"shop.shopware.com/v1",
+	"kind":"Store",
+	"metadata":{"name":"test","namespace":"default"},
+  "spec": {
+    "unknownField": "bar",
+    "lock": {"adapter":"builtin"},
+    "futureField": {"value":true}
+  }
+}`)
+	require.True(t, response.Allowed, response.Result.Message)
+}
+
+func TestStoreValidatorRejectsUnknownAdminDeploymentContainerField(t *testing.T) {
+	t.Parallel()
+
+	response := validateStore(t, admissionv1.Update, `{
+  "apiVersion":"shop.shopware.com/v1",
+  "kind":"Store",
+  "metadata":{"name":"test","namespace":"default"},
+  "spec": {
+    "adminDeploymentContainer": {
+      "unknownField": "bar"
+    }
+  }
+}`)
+
+	require.False(t, response.Allowed)
+	require.NotNil(t, response.Result)
+	assert.Contains(t, strings.ToLower(response.Result.Message), "unknown field")
+}
+
 func TestStoreValidatorRejectsInvalidOverrides(t *testing.T) {
 	t.Parallel()
 
@@ -41,7 +77,7 @@ func TestStoreValidatorRejectsInvalidOverrides(t *testing.T) {
 		message string
 	}{
 		"unknown field": {
-			raw:     `{"spec":{"workerDeploymentContainer":{"unknownField":true}}}`,
+			raw:     `{"spec":{"adminDeploymentContainer":{"unknownField":"bar"}}}`,
 			message: "unknown field",
 		},
 		"unknown nested field": {
@@ -50,6 +86,10 @@ func TestStoreValidatorRejectsInvalidOverrides(t *testing.T) {
 		},
 		"duplicate field": {
 			raw:     `{"spec":{"workerDeploymentContainer":{"replicas":1,"replicas":2}}}`,
+			message: "duplicate field",
+		},
+		"duplicate container override": {
+			raw:     `{"spec":{"adminDeploymentContainer":{},"adminDeploymentContainer":{}}}`,
 			message: "duplicate field",
 		},
 		"wrong field type": {
@@ -87,7 +127,7 @@ func TestStoreValidatorIgnoresOtherOperations(t *testing.T) {
 func validateStore(t *testing.T, operation admissionv1.Operation, raw string) admission.Response {
 	t.Helper()
 
-	return (StoreValidator{}).Handle(context.Background(), admission.Request{
+	return (StoreValidator{Logger: zap.NewNop().Sugar()}).Handle(context.Background(), admission.Request{
 		AdmissionRequest: admissionv1.AdmissionRequest{
 			Operation: operation,
 			Object: runtime.RawExtension{


### PR DESCRIPTION
- **fix: allow multiple installations with validating webhook**
- **fix: just validate container overwrites to not error on unrelated crd changes**

With the previous implementation the deployment of multiple installations of the operator due to a non namespace bound installation of the `ValidatingWebhookConfiguration`.
The installation is now namespace bound. 

Additionally, the validation logic was changed to only validate container overwrites and not error on unrelated CRD changes. This allows for more flexibility in managing CRDs without causing unnecessary deployment failures.
