### PR TITLE
fix(release): avoid jq ARG_MAX limit when encoding CRD files

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -121,8 +121,8 @@ jobs:
           additions=$(git diff --cached --name-status --no-renames \
             | awk -F'\t' '$1!="D"{print $2}' \
             | while read -r f; do
-                jq -n --arg path "$f" --arg contents "$(base64 -w0 "$f")" \
-                  '{path:$path, contents:$contents}'
+                base64 -w0 "$f" \
+                  | jq -Rs --arg path "$f" '{path:$path, contents:.}'
               done | jq -s '.')
           deletions=$(git diff --cached --name-status --no-renames \
             | awk -F'\t' '$1=="D"{print $2}' \


### PR DESCRIPTION
## Problem

The release workflow's `make pr on helm-charts` step failed with:

```
/usr/bin/jq: Argument list too long
##[error]Process completed with exit code 126.
```

The per-file addition builder passed the whole base64-encoded file as a jq command-line `--arg`:

```bash
jq -n --arg path "$f" --arg contents "$(base64 -w0 "$f")" '{path:$path, contents:$contents}'
```

Large CRD manifests produce base64 strings that exceed `ARG_MAX`, so exec fails before jq runs.

## Fix

Pipe the base64 contents into jq via stdin (`-Rs`) instead of passing it on argv — no argument-length limit:

```bash
base64 -w0 "$f" | jq -Rs --arg path "$f" '{path:$path, contents:.}'
```