### PR TITLE
fix: consume only default messenges and don't consume scheduled-tasks

### DIFF
--- a/internal/deployment/worker.go
+++ b/internal/deployment/worker.go
@@ -100,7 +100,7 @@ func WorkerDeployment(store v1.Store) *appsv1.Deployment {
 		})
 	}
 
-	consume := "bin/console messenger:consume --all --time-limit=300"
+	consume := "bin/console messenger:consume failed async low_priority webhook --time-limit=300"
 	if phpMemoryLimitMiB > 0 {
 		consume += fmt.Sprintf(" --memory-limit=%dM", phpMemoryLimitMiB)
 	}

--- a/internal/deployment/worker_test.go
+++ b/internal/deployment/worker_test.go
@@ -219,7 +219,7 @@ func TestWorkerDeployment(t *testing.T) {
 		// Verify worker command and args
 		assert.Equal(t, []string{"/bin/sh", "-c"}, container.Command)
 		assert.Len(t, container.Args, 1)
-		assert.Contains(t, container.Args[0], "bin/console messenger:consume --all --time-limit=300")
+		assert.Contains(t, container.Args[0], "bin/console messenger:consume failed async low_priority webhook --time-limit=300")
 		assert.NotContains(t, container.Args[0], "--memory-limit")
 		assert.Contains(t, container.Args[0], `trap 'kill -TERM "$child"`)
 		assert.Equal(t, "shopware-worker", container.Name)


### PR DESCRIPTION
This is currently an issue if the worker is scaling. Because
scheudled-task is also consumed with the --all flag, the first worker
locks all the others and no message gets queued. Therefore we have a
deadlock until the timeout kicks in
