### PR TITLE
fix: propagate snapshot annotations to pods

### DIFF
--- a/internal/job/snapshot.go
+++ b/internal/job/snapshot.go
@@ -156,7 +156,8 @@ func snapshotJob(store v1.Store, meta metav1.ObjectMeta, snapshot v1.StoreSnapsh
 			TTLSecondsAfterFinished: func(i int32) *int32 { return &i }(60),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: labels,
+					Labels:      labels,
+					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName:            snapshot.Container.ServiceAccountName,

--- a/internal/job/snapshot_test.go
+++ b/internal/job/snapshot_test.go
@@ -84,3 +84,31 @@ func TestSnapshotCreateJobPropagatesContainerAnnotationsToPodTemplate(t *testing
 	assert.Equal(t, "[]", result.Annotations["ad.datadoghq.com/operator-snapshot.logs"])
 	assert.Equal(t, "[]", result.Spec.Template.Annotations["ad.datadoghq.com/operator-snapshot.logs"])
 }
+
+func TestSnapshotRestoreJobPropagatesContainerAnnotationsToPodTemplate(t *testing.T) {
+	store := v1.Store{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-store",
+			Namespace: "test",
+		},
+	}
+
+	snapshot := v1.StoreSnapshotRestore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-snapshot",
+			Namespace: "test",
+		},
+		Spec: v1.StoreSnapshotSpec{
+			Container: v1.ContainerSpec{
+				Annotations: map[string]string{
+					"ad.datadoghq.com/operator-snapshot.logs": "[]",
+				},
+			},
+		},
+	}
+
+	result := job.SnapshotRestoreJob(store, snapshot)
+
+	assert.Equal(t, "[]", result.Annotations["ad.datadoghq.com/operator-snapshot.logs"])
+	assert.Equal(t, "[]", result.Spec.Template.Annotations["ad.datadoghq.com/operator-snapshot.logs"])
+}

--- a/internal/job/snapshot_test.go
+++ b/internal/job/snapshot_test.go
@@ -56,3 +56,31 @@ func TestSnapshotCreateJobUsesRestrictedContainerSecurityContext(t *testing.T) {
 	assert.Len(t, result.Spec.Template.Spec.Volumes, 2)
 	assert.Equal(t, "database-tls", result.Spec.Template.Spec.Volumes[0].Secret.SecretName)
 }
+
+func TestSnapshotCreateJobPropagatesContainerAnnotationsToPodTemplate(t *testing.T) {
+	store := v1.Store{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-store",
+			Namespace: "test",
+		},
+	}
+
+	snapshot := v1.StoreSnapshotCreate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-snapshot",
+			Namespace: "test",
+		},
+		Spec: v1.StoreSnapshotSpec{
+			Container: v1.ContainerSpec{
+				Annotations: map[string]string{
+					"ad.datadoghq.com/operator-snapshot.logs": "[]",
+				},
+			},
+		},
+	}
+
+	result := job.SnapshotCreateJob(store, snapshot)
+
+	assert.Equal(t, "[]", result.Annotations["ad.datadoghq.com/operator-snapshot.logs"])
+	assert.Equal(t, "[]", result.Spec.Template.Annotations["ad.datadoghq.com/operator-snapshot.logs"])
+}


### PR DESCRIPTION
## Summary
- propagate snapshot container annotations to the generated Job Pod template
- add regression coverage for Datadog-style container annotations

## Verification
- go test ./internal/job -count=1